### PR TITLE
Fix: Ensure ContextKey values are always encoded as base64 string independent of the external encoder configuration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "XCTAssertCrash",
         "repositoryURL": "https://github.com/norio-nomura/XCTAssertCrash.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,24 @@
         }
       },
       {
+        "package": "FineJSON",
+        "repositoryURL": "https://github.com/omochi/FineJSON.git",
+        "state": {
+          "branch": null,
+          "revision": "05101709243cb66d80c92e645210a3b80cf4e17f",
+          "version": "1.14.0"
+        }
+      },
+      {
+        "package": "RichJSONParser",
+        "repositoryURL": "https://github.com/omochi/RichJSONParser.git",
+        "state": {
+          "branch": null,
+          "revision": "263e2ecfe88d0500fa99e4cbc8c948529d335534",
+          "version": "3.0.0"
+        }
+      },
+      {
         "package": "swift-collections",
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -22,11 +22,15 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git", .upToNextMinor(from: "0.3.2")),
+        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/norio-nomura/XCTAssertCrash.git", from: "0.2.0")
     ],
     targets: [
         .target(
-            name: "ApodiniContext"
+            name: "ApodiniContext",
+            dependencies: [
+                .product(name: "OrderedCollections", package: "swift-collections")
+            ]
         ),
         .target(
             name: "MetadataSystem",

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git", .upToNextMinor(from: "0.3.2")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/norio-nomura/XCTAssertCrash.git", from: "0.2.0")
+        .package(url: "https://github.com/norio-nomura/XCTAssertCrash.git", from: "0.2.0"),
+        .package(url: "https://github.com/omochi/FineJSON.git", from: "1.14.0")
     ],
     targets: [
         .target(
@@ -55,7 +56,8 @@ let package = Package(
             name: "ApodiniContextTests",
             dependencies: [
                 .target(name: "XCTMetadataSystem"),
-                .target(name: "ApodiniContext")
+                .target(name: "ApodiniContext"),
+                .product(name: "FineJSON", package: "FineJSON")
             ]
         ),
         .testTarget(

--- a/Sources/ApodiniContext/CodableContextKey.swift
+++ b/Sources/ApodiniContext/CodableContextKey.swift
@@ -12,15 +12,14 @@ import Foundation
 public protocol AnyCodableContextKey: AnyContextKey {
     static var identifier: String { get }
 
-    static func anyEncode(value: Any) throws -> Data
+    static func anyEncode(value: Any) throws -> String
 }
 
 /// An ``OptionalContextKey`` which value is able to be encoded and decoded.
 public protocol CodableContextKey: AnyCodableContextKey, OptionalContextKey where Value: Codable {
-    static func decode(from data: Data) throws -> Value
+    static func decode(from base64String: String) throws -> Value
 }
 
-// Data, by default, is encoded as base64
 private let encoder = JSONEncoder()
 private let decoder = JSONDecoder()
 
@@ -29,15 +28,21 @@ extension CodableContextKey {
         "\(Self.self)"
     }
 
-    public static func anyEncode(value: Any) throws -> Data {
+    public static func anyEncode(value: Any) throws -> String {
         guard let value = value as? Self.Value else {
             fatalError("CodableContextKey.anyEncode(value:) received illegal value type \(type(of: value)) instead of \(Value.self)")
         }
 
-        return try encoder.encode(value)
+        return try encoder
+            .encode(value)
+            .base64EncodedString()
     }
 
-    public static func decode(from data: Data) throws -> Value {
-        try decoder.decode(Value.self, from: data)
+    public static func decode(from base64String: String) throws -> Value {
+        guard let data = Data(base64Encoded: base64String) else {
+            fatalError("Failed to unwrap bas64 encoded data string: \(base64String)")
+        }
+
+        return try decoder.decode(Value.self, from: data)
     }
 }

--- a/Sources/ApodiniContext/Context.swift
+++ b/Sources/ApodiniContext/Context.swift
@@ -28,9 +28,10 @@ public struct Context: ContextKeyRetrievable {
     private var entries: [ObjectIdentifier: StoredContextValue] {
         boxedEntries.entries
     }
-    private let decodedEntries: [String: Data]
+    /// Mapping from ``CodableContextKey/identifier`` to base64 encoded data
+    private let decodedEntries: [String: String]
 
-    init(_ entries: [ObjectIdentifier: StoredContextValue] = [:], _ decodedEntries: [String: Data] = [:]) {
+    init(_ entries: [ObjectIdentifier: StoredContextValue] = [:], _ decodedEntries: [String: String] = [:]) {
         self.boxedEntries = ContextBox(entries)
         self.decodedEntries = decodedEntries
     }
@@ -138,10 +139,10 @@ extension Context: Codable {
 
         self.boxedEntries = ContextBox([:])
 
-        var decodedEntries: [String: Data] = [:]
+        var decodedEntries: [String: String] = [:]
 
         for key in container.allKeys {
-            decodedEntries[key.stringValue] = try container.decode(Data.self, forKey: key)
+            decodedEntries[key.stringValue] = try container.decode(String.self, forKey: key)
         }
 
         self.decodedEntries = decodedEntries
@@ -150,7 +151,7 @@ extension Context: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StringContextKey.self)
 
-        var entries: [String: Data] = [:]
+        var entries: [String: String] = [:]
 
         for storedValue in self.entries.values {
             guard let contextKey = storedValue.key as? AnyCodableContextKey.Type else {
@@ -164,8 +165,8 @@ extension Context: Codable {
             fatalError("Encountered context value conflicts of \(current) and \(new)!")
         }
 
-        for (key, data) in entries {
-            try container.encode(data, forKey: StringContextKey(stringValue: key))
+        for (key, base64String) in entries {
+            try container.encode(base64String, forKey: StringContextKey(stringValue: key))
         }
     }
 }

--- a/Sources/ApodiniContext/Context.swift
+++ b/Sources/ApodiniContext/Context.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import OrderedCollections
 
 private class ContextBox {
     var entries: [ObjectIdentifier: StoredContextValue]
@@ -151,7 +152,7 @@ extension Context: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StringContextKey.self)
 
-        var entries: [String: String] = [:]
+        var entries: OrderedDictionary<String, String> = [:]
 
         for storedValue in self.entries.values {
             guard let contextKey = storedValue.key as? AnyCodableContextKey.Type else {
@@ -164,6 +165,8 @@ extension Context: Codable {
         entries.merge(self.decodedEntries) { current, new in
             fatalError("Encountered context value conflicts of \(current) and \(new)!")
         }
+
+        entries.sort()
 
         for (key, base64String) in entries {
             try container.encode(base64String, forKey: StringContextKey(stringValue: key))

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -88,20 +88,30 @@ class ContextKeyTests: XCTestCase {
             typealias Value = String
         }
 
+        struct CodableArrayStringContextKey: CodableContextKey {
+            typealias Value = [String]
+        }
+
         let context = Context()
         context.unsafeAdd(CodableStringContextKey.self, value: "Hello World")
         XCTAssertRuntimeFailure(context.unsafeAdd(CodableStringContextKey.self, value: "Hello Mars"))
+        context.unsafeAdd(CodableArrayStringContextKey.self, value: ["Hello Sun"])
 
         XCTAssertEqual(context.get(valueFor: CodableStringContextKey.self), "Hello World")
         XCTAssertEqual(context.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
+        XCTAssertEqual(context.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
 
         let encoder = JSONEncoder()
+        encoder.dataEncodingStrategy = .deferredToData
         let decoder = JSONDecoder()
+        decoder.dataDecodingStrategy = .deferredToData
 
         let encodedContext = try encoder.encode(context)
+        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\",\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\"}")
         let decodedContext = try decoder.decode(Context.self, from: encodedContext)
 
         XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello World")
         XCTAssertEqual(decodedContext.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
+        XCTAssertEqual(decodedContext.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
     }
 }

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -88,12 +88,18 @@ class ContextKeyTests: XCTestCase {
             typealias Value = String
         }
 
+        struct CodableArrayStringContextKey: CodableContextKey {
+            typealias Value = [String]
+        }
+
         let context = Context()
         context.unsafeAdd(CodableStringContextKey.self, value: "Hello World")
         XCTAssertRuntimeFailure(context.unsafeAdd(CodableStringContextKey.self, value: "Hello Mars"))
+        context.unsafeAdd(CodableArrayStringContextKey.self, value: ["Hello Sun"])
 
         XCTAssertEqual(context.get(valueFor: CodableStringContextKey.self), "Hello World")
         XCTAssertEqual(context.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
+        XCTAssertEqual(context.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
 
         let encoder = JSONEncoder()
         encoder.dataEncodingStrategy = .deferredToData
@@ -101,10 +107,11 @@ class ContextKeyTests: XCTestCase {
         decoder.dataDecodingStrategy = .deferredToData
 
         let encodedContext = try encoder.encode(context)
-        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\"}")
+        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\",\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\"}")
         let decodedContext = try decoder.decode(Context.self, from: encodedContext)
 
         XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello World")
         XCTAssertEqual(decodedContext.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
+        XCTAssertEqual(decodedContext.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
     }
 }

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -103,10 +103,11 @@ class ContextKeyTests: XCTestCase {
         XCTAssertEqual(context.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
 
         let encoder = FineJSONEncoder()
+        encoder.jsonSerializeOptions = .init(isPrettyPrint: false)
         let decoder = FineJSONDecoder()
 
         let encodedContext = try encoder.encode(context)
-        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\",\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\"}")
+        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\",\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\"}")
         let decodedContext = try decoder.decode(Context.self, from: encodedContext)
 
         XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello World")

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -88,18 +88,12 @@ class ContextKeyTests: XCTestCase {
             typealias Value = String
         }
 
-        struct CodableArrayStringContextKey: CodableContextKey {
-            typealias Value = [String]
-        }
-
         let context = Context()
         context.unsafeAdd(CodableStringContextKey.self, value: "Hello World")
         XCTAssertRuntimeFailure(context.unsafeAdd(CodableStringContextKey.self, value: "Hello Mars"))
-        context.unsafeAdd(CodableArrayStringContextKey.self, value: ["Hello Sun"])
 
         XCTAssertEqual(context.get(valueFor: CodableStringContextKey.self), "Hello World")
         XCTAssertEqual(context.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
-        XCTAssertEqual(context.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
 
         let encoder = JSONEncoder()
         encoder.dataEncodingStrategy = .deferredToData
@@ -107,11 +101,10 @@ class ContextKeyTests: XCTestCase {
         decoder.dataDecodingStrategy = .deferredToData
 
         let encodedContext = try encoder.encode(context)
-        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\",\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\"}")
+        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\"}")
         let decodedContext = try decoder.decode(Context.self, from: encodedContext)
 
         XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello World")
         XCTAssertEqual(decodedContext.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
-        XCTAssertEqual(decodedContext.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
     }
 }

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import XCTMetadataSystem
 @testable import ApodiniContext
+import FineJSON
 
 class ContextKeyTests: XCTestCase {
     func testContextKeys() {
@@ -101,10 +102,8 @@ class ContextKeyTests: XCTestCase {
         XCTAssertEqual(context.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
         XCTAssertEqual(context.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
 
-        let encoder = JSONEncoder()
-        encoder.dataEncodingStrategy = .deferredToData
-        let decoder = JSONDecoder()
-        decoder.dataDecodingStrategy = .deferredToData
+        let encoder = FineJSONEncoder()
+        let decoder = FineJSONDecoder()
 
         let encodedContext = try encoder.encode(context)
         XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\",\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\"}")


### PR DESCRIPTION


<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix: Ensure ContextKey values are always encoded as base64 string independent of the external encoder configuration

## :recycle: Current situation & Problem
Currently, by accident, we rely on the user supplied encoder and decoder to handle the `Data` of our `CodableContextKeys`.

## :bulb: Proposed solution
This PR fixes this my enforcing base64 encoding.

## :gear: Release Notes 
* Fixed encoding of `Context`

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
Adjusted test case to catch this regression.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
