### PR TITLE
Add option to allow ContextKey overwrite on `unsafeAdd`

### DIFF
--- a/Sources/ApodiniContext/CodableContextKey.swift
+++ b/Sources/ApodiniContext/CodableContextKey.swift
@@ -24,10 +24,12 @@ private let encoder = JSONEncoder()
 private let decoder = JSONDecoder()
 
 extension CodableContextKey {
+    /// Default identifier is derived from the swift type name
     public static var identifier: String {
         "\(Self.self)"
     }
 
+    /// Default implementation for anyEncode to base64 string.
     public static func anyEncode(value: Any) throws -> String {
         guard let value = value as? Self.Value else {
             fatalError("CodableContextKey.anyEncode(value:) received illegal value type \(type(of: value)) instead of \(Value.self)")
@@ -38,6 +40,7 @@ extension CodableContextKey {
             .base64EncodedString()
     }
 
+    /// Default implementation for decode from base64 string.
     public static func decode(from base64String: String) throws -> Value {
         guard let data = Data(base64Encoded: base64String) else {
             fatalError("Failed to unwrap bas64 encoded data string: \(base64String)")

--- a/Sources/ApodiniContext/Context.swift
+++ b/Sources/ApodiniContext/Context.swift
@@ -89,10 +89,12 @@ public struct Context: ContextKeyRetrievable {
     /// - Parameters:
     ///   - contextKey: The context to add value for.
     ///   - value: The value to add.
-    public func unsafeAdd<C: OptionalContextKey>(_ contextKey: C.Type = C.self, value: C.Value) {
+    ///   - allowOverwrite: This Bool controls if the unsafe addition should allow overwriting an existing entry.
+    ///     Use this option with caution! This method does NOT reduce multiple values for the same key. It OVERWRITES!
+    public func unsafeAdd<C: OptionalContextKey>(_ contextKey: C.Type = C.self, value: C.Value, allowOverwrite: Bool = false) {
         let key = ObjectIdentifier(contextKey)
 
-        precondition(entries[key] == nil, "Cannot overwrite existing ContextKey entry with `unsafeAdd`: \(C.self): \(value)")
+        precondition(entries[key] == nil || allowOverwrite, "Cannot overwrite existing ContextKey entry with `unsafeAdd`: \(C.self): \(value)")
         if let codableContextKey = contextKey as? AnyCodableContextKey.Type {
             // we need to prevent this. as Otherwise we would need to handle merging this stuff which get really complex
             precondition(decodedEntries[codableContextKey.identifier] == nil, "Cannot overwrite existing CodableContextKey entry with `unsafeAdd`: \(C.self): \(value)")

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -114,4 +114,17 @@ class ContextKeyTests: XCTestCase {
         XCTAssertEqual(decodedContext.get(valueFor: RequiredCodableStringContextKey.self), "Default Value!")
         XCTAssertEqual(decodedContext.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
     }
+
+    func testUnsafeAddAllowingOverwrite() {
+        struct CodableStringContextKey: CodableContextKey {
+            typealias Value = String
+        }
+
+        let context = Context()
+
+        context.unsafeAdd(CodableStringContextKey.self, value: "Hello World")
+        XCTAssertEqual(context.get(valueFor: CodableStringContextKey.self), "Hello World")
+        context.unsafeAdd(CodableStringContextKey.self, value: "Hello Mars", allowOverwrite: true)
+        XCTAssertEqual(context.get(valueFor: CodableStringContextKey.self), "Hello Mars")
+    }
 }

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -107,7 +107,10 @@ class ContextKeyTests: XCTestCase {
         let decoder = FineJSONDecoder()
 
         let encodedContext = try encoder.encode(context)
-        XCTAssertEqual(String(data: encodedContext, encoding: .utf8), "{\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\",\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\"}")
+        XCTAssertEqual(
+            String(data: encodedContext, encoding: .utf8),
+            "{\"CodableArrayStringContextKey\":\"WyJIZWxsbyBTdW4iXQ==\",\"CodableStringContextKey\":\"IkhlbGxvIFdvcmxkIg==\"}"
+        )
         let decodedContext = try decoder.decode(Context.self, from: encodedContext)
 
         XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello World")


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Add option to allow ContextKey overwrite on `unsafeAdd`

## :recycle: Current situation & Problem
Currently, the `Context/unsafeAdd` method disallow wiring into the Context if a value for the given Context is already present. In certain contains, where all side effects are under control, one might still want to replace the valve even if it is unsafe and doesn't support ContextKey reduction.

## :bulb: Proposed solution
This PR adds a `allowOverwrite` option which must **explicitly** set. This adds enough flexible while at the same time ensures that the user is aware of the risks.

## :gear: Release Notes 
* Added `allowOverwrite` parameter to `Context/unsafeAdd`.

## :heavy_plus_sign: Additional Information

### Related PRs
-

### Testing
An sdditional test case was added.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
