### PR TITLE
Fixed: allowOverwrite will now properly consider CodableContextKeys

### DIFF
--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -118,7 +118,7 @@ class ContextKeyTests: XCTestCase {
         XCTAssertEqual(decodedContext.get(valueFor: CodableArrayStringContextKey.self), ["Hello Sun"])
     }
 
-    func testUnsafeAddAllowingOverwrite() {
+    func testUnsafeAddAllowingOverwrite() throws {
         struct CodableStringContextKey: CodableContextKey {
             typealias Value = String
         }
@@ -129,5 +129,20 @@ class ContextKeyTests: XCTestCase {
         XCTAssertEqual(context.get(valueFor: CodableStringContextKey.self), "Hello World")
         context.unsafeAdd(CodableStringContextKey.self, value: "Hello Mars", allowOverwrite: true)
         XCTAssertEqual(context.get(valueFor: CodableStringContextKey.self), "Hello Mars")
+
+        let encoder = FineJSONEncoder()
+        encoder.jsonSerializeOptions = .init(isPrettyPrint: false)
+        let decoder = FineJSONDecoder()
+
+        let encodedContext = try encoder.encode(context)
+        XCTAssertEqual(
+            String(data: encodedContext, encoding: .utf8),
+            "{\"CodableStringContextKey\":\"IkhlbGxvIE1hcnMi\"}"
+        )
+
+        let decodedContext = try decoder.decode(Context.self, from: encodedContext)
+
+        decodedContext.unsafeAdd(CodableStringContextKey.self, value: "Hello Saturn", allowOverwrite: true)
+        XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello Saturn")
     }
 }


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fixed: unsafeOverwrite will now properly consider CodableContextKeys

## :recycle: Current situation & Problem
#5  introduced the `allowOverwrite` for the `unsafeAdd` method. Calls to this method with the flag turned on were still rejected for `CodableContextKey`s.

## :bulb: Proposed solution
This PR fixes this issue.

## :gear: Release Notes 
* Fixed an issue were `allowOverwrite` would not work for `CodableContextKey`s.

## :heavy_plus_sign: Additional Information

### Related PRs
- #5 

### Testing
Testing as adjusted to include this case.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
