### PR TITLE
Fixed an issue where decoded CodableContextKey values became inaccesible after the first access

### DIFF
--- a/Sources/ApodiniContext/Context.swift
+++ b/Sources/ApodiniContext/Context.swift
@@ -121,7 +121,9 @@ public struct Context: ContextKeyRetrievable {
         }
 
         do {
-            return try Key.decode(from: dataValue)
+            let value = try Key.decode(from: dataValue)
+            boxedEntries.entries[ObjectIdentifier(key)] = StoredContextValue(key: key, value: value)
+            return value
         } catch {
             fatalError("Error occurred when trying to decode `CodableContextKey` `\(Key.self)` with stored value '\(dataValue)': \(error)")
         }

--- a/Tests/ApodiniContextTests/ContextKeyTests.swift
+++ b/Tests/ApodiniContextTests/ContextKeyTests.swift
@@ -141,6 +141,8 @@ class ContextKeyTests: XCTestCase {
         )
 
         let decodedContext = try decoder.decode(Context.self, from: encodedContext)
+        XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello Mars")
+        XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello Mars")
 
         decodedContext.unsafeAdd(CodableStringContextKey.self, value: "Hello Saturn", allowOverwrite: true)
         XCTAssertEqual(decodedContext.get(valueFor: CodableStringContextKey.self), "Hello Saturn")


### PR DESCRIPTION


<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fixed an issue where decoded CodableContextKey values became inaccesible after the first access

## :recycle: Current situation & Problem
#6 introduced an optimization to only decode `CodableContextKey`s once for `Context` instance constructed from a Decoder. The PR introduced an issue where the CodableContextKey value became inaccessible after the first retrieval.

## :gear: Release Notes 
* Fixed an issue where decoded CodableContextKey values became inaccesible after the first access

## :heavy_plus_sign: Additional Information

### Related PRs
- #6 

### Testing
Regression testing was added.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
