### PR TITLE
Swift 5.7 support: Replace the AssociatedTypeRequirementsKit package with native casts

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AssociatedTypeRequirementsKit",
-        "repositoryURL": "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git",
-        "state": {
-          "branch": null,
-          "revision": "2e4c49c21ffb2135f1c99fbfcf2119c9d24f5e8c",
-          "version": "0.3.2"
-        }
-      },
-      {
         "package": "FineJSON",
         "repositoryURL": "https://github.com/omochi/FineJSON.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 //
 // This source file is part of the Apodini open source project

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
         .library(name: "MetadataSystem", targets: ["MetadataSystem"])
     ],
     dependencies: [
-        .package(url: "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git", .upToNextMinor(from: "0.3.2")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/norio-nomura/XCTAssertCrash.git", from: "0.2.0"),
         .package(url: "https://github.com/omochi/FineJSON.git", from: "1.14.0")
@@ -36,8 +35,7 @@ let package = Package(
         .target(
             name: "MetadataSystem",
             dependencies: [
-                .target(name: "ApodiniContext"),
-                .product(name: "AssociatedTypeRequirementsKit", package: "AssociatedTypeRequirementsKit")
+                .target(name: "ApodiniContext")
             ]
         ),
         .target(

--- a/Sources/MetadataSystem/MetadataParser.swift
+++ b/Sources/MetadataSystem/MetadataParser.swift
@@ -81,9 +81,6 @@ extension MetadataParser {
         } else {
             self.visit(definition: definition)
         }
-//        if StandardEmptyMetadataVisitor(parser: self)(definition) == nil {
-//            self.visit(definition: definition)
-//        }
     }
 
     // swiftlint:disable:next identifier_name
@@ -93,9 +90,6 @@ extension MetadataParser {
         } else {
             self.visit(block: block)
         }
-//        if StandardRestrictedMetadataBlockVisitor(parser: self)(block) == nil {
-//            self.visit(block: block)
-//        }
     }
 }
 


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Swift 5.7 support

## :recycle: Current situation & Problem
The AssociatedTypeRequirementsKit package doesn't seem to work in release builds in Swift 5.7.

## :bulb: Proposed solution
We remove the dependency on the AssociatedTypeRequirementsKit package, and instead uses native Swift casts.

## :gear: Release Notes 
- Internal bug fixes

## :heavy_plus_sign: Additional Information
n/a

### Related PRs
- https://github.com/Apodini/ApodiniTypeInformation/pull/16
- https://github.com/Apodini/Apodini/pull/446

### Testing
n/a, no functionality was changed

### Reviewer Nudging
the code diff

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
